### PR TITLE
Fix frame switching in exception chains

### DIFF
--- a/starception/templates/frame_line.html
+++ b/starception/templates/frame_line.html
@@ -8,7 +8,7 @@
     {% set extra_css_class = extra_css_class ~ ' ' ~ ' current' %}
 {% endif %}
 
-<div class="frame {{ extra_css_class }}" id="switch-{{ frame|frame_id }}" data-frame-index="{{ frame|frame_id }}">
+<div class="frame {{ extra_css_class }}" id="switch-{{ frame|frame_id }}" data-frame-index="{{ frame|frame_id }}" data-trace-target-index="{{ stackloop.index0 }}">
     <div class="dot {{ '' if frame|is_vendor else 'dot-red' }}"></div>
     <div>
         <span class="text-muted">

--- a/starception/templates/index.html
+++ b/starception/templates/index.html
@@ -22,6 +22,7 @@
 <main>
     <!-- exception block -->
     {% for stack_item in stack %}
+        {% set stackloop = loop %}
         <div>
             {% if loop.index0 > 0 %}
                 <header class="section-header" data-toggle-trace="" data-trace-index="{{ loop.index0 }}">
@@ -31,7 +32,7 @@
                     </div>
                 </header>
             {% endif %}
-            <div data-trace-target="{{ loop.index0 }}" {% if loop.index0 > 0 %} class="collapsed"{% endif %}>
+            <div id="trace-target-{{ loop.index0 }}" data-trace-target="{{ loop.index0 }}" {% if loop.index0 > 0 %} class="collapsed"{% endif %}>
                 {% if loop.index0 > 0 %}
                     {% if stack_item.solution %}
                         <div style="padding: 0 48px">

--- a/starception/templates/scripts.js
+++ b/starception/templates/scripts.js
@@ -1,17 +1,19 @@
 Array.from(document.querySelectorAll('[id^="switch"]')).forEach(function (el) {
     el.addEventListener('click', function () {
-        var current = document.querySelector('.snippet-wrapper.current');
+        var traceIndex = el.dataset.traceTargetIndex;
+        var traceElement = document.querySelector('#trace-target-' + traceIndex);
+        var current = traceElement.querySelector('.snippet-wrapper.current');
         if (current) {
             current.classList.remove('current');
         }
 
         var frameIndex = el.dataset.frameIndex;
-        var target = document.querySelector('#snippet-' + frameIndex);
+        var target = traceElement.querySelector('#snippet-' + frameIndex);
         if (target) {
             target.classList.add('current');
         }
 
-        var currentSwitch = document.querySelector('.frame.current');
+        var currentSwitch = traceElement.querySelector('.frame.current');
         if (currentSwitch) {
             currentSwitch.classList.remove('current');
         }


### PR DESCRIPTION
Frame switching doesn't work properly with exception chains

<details>
  <summary>Video highlighting the problem</summary>
  
https://user-images.githubusercontent.com/153191/196199576-3c2f83c8-4ad5-4841-8496-ceef65732522.mp4
</details>

This happens because when a new frame is selected JS hides the very first open code snippet and reveals snippet corresponding to the selected frame. It works fine when there is only one stack trace on the page or when you pick frames from the very first stack trace.

Solution is simple:
* add corresponding stack trace id to each frame
* on frame click perform selector queries only inside div with matching stack trace id

<details>
  <summary>Video showing the fix</summary>
  
https://user-images.githubusercontent.com/153191/196199935-9c3581b4-4c22-4af3-bb15-d7dddd819edf.mp4
</details>
