### PR TITLE
Hide vendor frames toggle if there are none of them

### DIFF
--- a/starception/templates/index.html
+++ b/starception/templates/index.html
@@ -48,11 +48,13 @@
                     {% endfor %}
 
                     <div class="frames">
-                        <div style="margin-bottom: 10px">
-                            <label class="checkbox">
-                                <input type="checkbox" id="vendor-frames" checked> Hide vendor frames
-                            </label>
-                        </div>
+                        {% if stack_item.has_vendor_frames %}
+                            <div style="margin-bottom: 10px">
+                                <label class="checkbox">
+                                    <input type="checkbox" class="vendor-frames-toggle" data-trace-target-index="{{ stackloop.index0 }}" checked> Hide vendor frames
+                                </label>
+                            </div>
+                        {% endif %}
                         {% for frame in stack_item.frames|reverse %}
                             {% with frame=frame, is_current=loop.first %}
                                 {% include 'frame_line.html' %}

--- a/starception/templates/scripts.js
+++ b/starception/templates/scripts.js
@@ -29,13 +29,17 @@ Array.from(document.querySelectorAll('[data-reveal]')).forEach(function (el) {
 });
 
 
-document.querySelector('#vendor-frames').addEventListener('click', function (e) {
-    Array.from(document.querySelectorAll('.frames .vendor')).forEach(function (frame) {
-        if (e.target.checked) {
-            frame.classList.add('hidden');
-        } else {
-            frame.classList.remove('hidden');
-        }
+document.querySelectorAll('.vendor-frames-toggle').forEach(function (toggle) {
+    toggle.addEventListener('click', function (e) {
+        var traceIndex = toggle.dataset.traceTargetIndex;
+        var traceElement = document.querySelector('#trace-target-' + traceIndex);
+        Array.from(traceElement.querySelectorAll('.frames .vendor')).forEach(function (frame) {
+            if (e.target.checked) {
+                frame.classList.add('hidden');
+            } else {
+                frame.classList.remove('hidden');
+            }
+        });
     });
 });
 


### PR DESCRIPTION
This PR adds conditional rendering of "Hide vendor frames" toggle which is needed for exception chains.

Also, it addresses browser complaints about non-uniqe id/non-existent elements by searching vendor frames inside specific stack trace div (instead of entire document)